### PR TITLE
feat: add ifconfig.me IP query channel

### DIFF
--- a/Browserapp/automation/proxy-store.js
+++ b/Browserapp/automation/proxy-store.js
@@ -3,7 +3,7 @@
 const fsp = require('fs/promises');
 const path = require('path');
 const crypto = require('crypto');
-const { parseProxy, displayProxy } = require('../proxy-forwarder');
+const { parseProxy, displayProxy, normalizeIpLookupChannel } = require('../proxy-forwarder');
 
 /**
  * Local proxy library (proxy-list CRUD, self-contained).
@@ -22,9 +22,7 @@ function normalizeProxyRecord(input = {}, existing = null) {
   const username = String(input.username ?? input.user ?? existing?.username ?? '');
   const password = String(input.password ?? existing?.password ?? '');
   const refreshUrl = String(input.refreshUrl || input.refresh_url || existing?.refreshUrl || '').slice(0, 1000);
-  const ipChannel = ['ip-api', 'ip2location'].includes(String(input.ipChannel || existing?.ipChannel || ''))
-    ? String(input.ipChannel || existing?.ipChannel)
-    : 'ip-api';
+  const ipChannel = normalizeIpLookupChannel(input.ipChannel || existing?.ipChannel);
 
   let raw = String(input.raw || input.proxy || '').trim();
   if (!raw) {

--- a/Browserapp/engine.js
+++ b/Browserapp/engine.js
@@ -7,7 +7,7 @@ const { spawn, execFileSync } = require('child_process');
 const cdp = require('./cdp');
 const { addChromeStoreExtension } = require('./store-extension');
 const { reconcileOnConnection, portConnection } = require('./extension-pipe');
-const { parseProxy, displayProxy, startAuthenticatedProxy, lookupProxyCountry, lookupDirectCountry, extractProxyFromApi, invokeProxyRefresh, classifyProxyError } = require('./proxy-forwarder');
+const { parseProxy, displayProxy, startAuthenticatedProxy, lookupProxyCountry, lookupDirectCountry, extractProxyFromApi, invokeProxyRefresh, classifyProxyError, normalizeIpLookupChannel } = require('./proxy-forwarder');
 const { resolveProfileLanguage, localeFromCountryCode } = require('./automation/locale-from-country');
 const { mergeLoadExtensionArgs } = require('./automation/protocol/app-center-protocol');
 const { prepareMarkerExtension, prepareMacDockWrapper, normalizeEnvNumber } = require('./automation/env-icon');
@@ -396,7 +396,7 @@ class BrowserEngine {
         totpSecret: String(platformValue.totpSecret || platformValue.otp || '').slice(0, 200),
       },
       proxyMeta: {
-        ipChannel: allowed(proxyMetaValue.ipChannel, ['ip-api', 'ip2location'], 'ip-api'),
+        ipChannel: normalizeIpLookupChannel(proxyMetaValue.ipChannel),
         refreshUrl: String(proxyMetaValue.refreshUrl || '').slice(0, 1000),
         checkOnStart: Boolean(proxyMetaValue.checkOnStart),
         refreshOnStart: Boolean(proxyMetaValue.refreshOnStart),
@@ -2535,7 +2535,9 @@ class BrowserEngine {
       resolved = await this.resolveProfileProxyConfig(profile, { allowExtract: options.allowExtract !== false });
     }
     try {
-      const result = await retryProxyOperation(() => lookupProxyCountry(resolved.config));
+      const result = await retryProxyOperation(() => lookupProxyCountry(resolved.config, {
+        ipChannel: profile.proxyMeta?.ipChannel,
+      }));
       return {
         ...result,
         protocol: resolved.config.protocol,

--- a/Browserapp/index.html
+++ b/Browserapp/index.html
@@ -227,7 +227,7 @@
                 <div id="editor-proxy-fields">
                   <div class="form-two">
                     <label>代理类型<select id="editor-proxy-type"><option value="socks5">SOCKS5</option><option value="http">HTTP</option><option value="https">HTTPS</option></select></label>
-                    <label>IP 查询通道<select id="editor-ip-channel"><option value="ip-api">IP-API</option><option value="ip2location">IP2Location</option></select></label>
+                    <label>IP 查询通道<select id="editor-ip-channel"><option value="ip-api">IP-API</option><option value="ip2location">IP2Location</option><option value="ifconfig-me">ifconfig.me（HTTPS）</option></select></label>
                   </div>
                   <div class="proxy-host-row">
                     <label>代理主机<input id="editor-proxy-host" placeholder="127.0.0.1"></label>
@@ -1070,6 +1070,7 @@
           <select id="proxy-ip-channel">
             <option value="ip-api">IP-API</option>
             <option value="ip2location">IP2Location</option>
+            <option value="ifconfig-me">ifconfig.me（HTTPS）</option>
           </select>
         </label>
       </div>

--- a/Browserapp/proxy-feature-selftest.js
+++ b/Browserapp/proxy-feature-selftest.js
@@ -80,6 +80,7 @@ async function main() {
     networkMode: 'proxy',
     proxy: 'socks5://127.0.0.1:1080',
     proxyMeta: {
+      ipChannel: 'ifconfig.me',
       checkOnStart: true,
       refreshOnStart: true,
       apiExtractUrl: `${base}/extract-text`,
@@ -89,6 +90,7 @@ async function main() {
     },
     privacy: { languageMode: 'ip', timezoneMode: 'ip', geoMode: 'ip' },
   });
+  assert.strictEqual(sanitized.proxyMeta.ipChannel, 'ifconfig-me');
   assert.strictEqual(sanitized.proxyMeta.refreshOnStart, true);
   assert.strictEqual(sanitized.proxyMeta.fillFingerprint, false);
   assert.deepStrictEqual(sanitized.proxyMeta.backupProxies, ['socks5://127.0.0.1:1081', 'http://127.0.0.1:8080']);
@@ -226,7 +228,8 @@ async function main() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pxf-'));
   const store = new ProxyStore(path.join(dir, 'p.json'));
   await store.load();
-  const item = await store.create({ raw: 'socks5://127.0.0.1:9', name: 'x' });
+  const item = await store.create({ raw: 'socks5://127.0.0.1:9', name: 'x', ipChannel: 'ifconfig.me' });
+  assert.strictEqual(store.get(item.id).ipChannel, 'ifconfig-me');
   await store.markCheck(item.id, { ip: '8.8.8.8', countryCode: 'US', latencyMs: 12, networkType: 'broadband' });
   assert.strictEqual(store.get(item.id).lastLatencyMs, 12);
   assert.strictEqual(store.get(item.id).lastCheckOk, true);
@@ -256,6 +259,7 @@ async function main() {
   ]) {
     assert.ok(html.includes(`id="${id}"`), 'missing html id ' + id);
   }
+  assert.ok(html.includes('value="ifconfig-me"'), 'ifconfig.me must be selectable as an IP query channel');
   assert.ok(renderer.includes("requireReady: $('#editor-proxy-require-ready')"), 'editor draft must collect requireReady');
   assert.ok(renderer.includes("notReadyPolicy: $('#editor-proxy-not-ready-policy')"), 'editor draft must collect notReadyPolicy');
   assert.ok(renderer.includes("tlsProfile: $('#editor-proxy-tls-profile')"), 'editor draft must collect tlsProfile');

--- a/Browserapp/proxy-forwarder-selftest.js
+++ b/Browserapp/proxy-forwarder-selftest.js
@@ -1,6 +1,12 @@
 const assert = require('assert');
 const net = require('net');
-const { parseProxy, displayProxy, startAuthenticatedProxy } = require('./proxy-forwarder');
+const {
+  parseProxy,
+  displayProxy,
+  startAuthenticatedProxy,
+  normalizeIpLookupChannel,
+  normalizeIfconfigMeResult,
+} = require('./proxy-forwarder');
 
 function listen(server) {
   return new Promise((resolve, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', () => resolve(server.address().port)); });
@@ -32,6 +38,11 @@ async function run() {
   assert.strictEqual(socks.authenticated, true);
   assert.strictEqual(parseProxy('socks5://127.0.0.1:1080').chromeUrl, 'socks5://127.0.0.1:1080');
   assert.throws(() => parseProxy('bad-format'));
+  assert.strictEqual(normalizeIpLookupChannel('ifconfig.me'), 'ifconfig-me');
+  assert.strictEqual(normalizeIpLookupChannel('unknown-provider'), 'ip-api');
+  assert.strictEqual(normalizeIfconfigMeResult('203.0.113.8\n').ip, '203.0.113.8');
+  assert.strictEqual(normalizeIfconfigMeResult('2001:db8::8').source, 'ifconfig.me');
+  assert.throws(() => normalizeIfconfigMeResult('<html>not an IP</html>'));
 
   let receivedHeader = '';
   const upstream = net.createServer((socket) => {
@@ -57,7 +68,7 @@ async function run() {
   const echoed = await until(client, Buffer.from('PING'));
   assert(echoed.includes(Buffer.from('PING')));
   client.destroy(); await forwarder.close(); await new Promise((resolve) => upstream.close(resolve));
-  console.log('PROXY_FORWARDER_SELFTEST_OK formats=4 auth_header=1 connect_tunnel=1 echo=1 credentials_masked=1');
+  console.log('PROXY_FORWARDER_SELFTEST_OK formats=4 ifconfig_ip=1 auth_header=1 connect_tunnel=1 echo=1 credentials_masked=1');
 }
 
 run().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/Browserapp/proxy-forwarder.js
+++ b/Browserapp/proxy-forwarder.js
@@ -1,6 +1,14 @@
 const net = require('net');
 const tls = require('tls');
 
+const IP_LOOKUP_CHANNELS = Object.freeze(['ip-api', 'ip2location', 'ifconfig-me']);
+
+function normalizeIpLookupChannel(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  if (raw === 'ifconfig' || raw === 'ifconfig.me' || raw === 'ifconfig-me') return 'ifconfig-me';
+  return IP_LOOKUP_CHANNELS.includes(raw) ? raw : 'ip-api';
+}
+
 function decode(value) {
   try { return decodeURIComponent(value); } catch (_) { return value; }
 }
@@ -1054,20 +1062,28 @@ async function invokeProxyRefresh(url) {
   };
 }
 
-async function lookupProxyCountry(config) {
+async function lookupProxyCountry(config, options = {}) {
   const started = Date.now();
+  const ipChannel = normalizeIpLookupChannel(options.ipChannel || options.channel);
   try {
-    const parts = await raceSettledValues([
+    const fallbackLookups = [
       () => lookupProxyIpApi(config),
       () => lookupProxyIpWho(config),
       () => lookupProxyIpInfo(config),
       () => lookupProxyCloudflareTrace(config),
-    ], { maxWaitMs: 12000 });
+    ];
+    // ifconfig.me is IP-only; keep the existing geo providers in the same
+    // request cycle so selecting it does not leave locale/timezone blank.
+    const lookups = ipChannel === 'ifconfig-me'
+      ? [() => lookupProxyIfconfigMe(config), ...fallbackLookups]
+      : [...fallbackLookups, () => lookupProxyIfconfigMe(config)];
+    const parts = await raceSettledValues(lookups, { maxWaitMs: 12000 });
     if (!parts.length) throw new Error('Proxy exit lookup failed on all sources');
     const result = mergeNetworkLookups(parts);
     const latencyMs = Date.now() - started;
     return enrichWithIpPure({
       ...result,
+      ipChannel,
       latencyMs,
       networkType: networkTypeFromLookup(result),
     }, () => lookupIpPureProxy(config));
@@ -1186,6 +1202,29 @@ async function lookupProxyCloudflareTrace(config) {
   return parseCloudflareTrace(response.body.toString('utf8'));
 }
 
+/**
+ * HTTPS egress-IP probe requested by the product: https://ifconfig.me/ip.
+ * The endpoint is deliberately IP-only, so geo data continues to come from
+ * the existing providers while this confirms that the configured proxy can
+ * reach ifconfig.me over TLS and exposes a valid public exit address.
+ */
+function normalizeIfconfigMeResult(value) {
+  const ip = String(value || '').trim();
+  if (!net.isIP(ip)) throw new Error('ifconfig.me response did not contain a valid IP address');
+  return {
+    ip,
+    source: 'ifconfig.me',
+    geoRole: 'egress',
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+async function lookupProxyIfconfigMe(config) {
+  const response = await requestProxyHttps(config, 'ifconfig.me', '/ip');
+  if (response.status !== 200) throw new Error('ifconfig.me proxy check returned HTTP ' + response.status);
+  return normalizeIfconfigMeResult(response.body.toString('utf8'));
+}
+
 async function probeProxyTunnel(config, hostname = 'www.google.com', port = 443) {
   const bridge = await startAuthenticatedProxy(config); let socket;
   try {
@@ -1217,12 +1256,14 @@ async function probeProxyHttps(config, hostname = 'www.google.com', pathname = '
 module.exports = {
   parseProxy,
   displayProxy,
+  normalizeIpLookupChannel,
   startAuthenticatedProxy,
   lookupProxyCountry,
   lookupDirectCountry,
   mergeNetworkLookups,
   parseCloudflareTrace,
   normalizeIpInfoResult,
+  normalizeIfconfigMeResult,
   probeProxyTunnel,
   probeProxyHttps,
   classifyProxyError,


### PR DESCRIPTION
## Summary
- Add `ifconfig-me` as an environment and proxy-library IP query channel.
- Normalize `ifconfig` and `ifconfig.me` aliases.
- Query `https://ifconfig.me/ip` through the configured proxy and retain existing sources for geo enrichment.

## Validation
- `node proxy-forwarder-selftest.js`
- `node proxy-feature-selftest.js`
- Live configured-proxy check through `127.0.0.1:10808`