### PR TITLE
feat: add profile create/delete endpoints to Local API

### DIFF
--- a/Browserapp/automation/local-api-server.js
+++ b/Browserapp/automation/local-api-server.js
@@ -186,7 +186,52 @@ class LocalApiServer {
       return ok({ list, page: 1, page_size: list.length });
     }
 
-    if (pathname === '/api/v1/browser/start' || pathname === '/api/v2/browser-profile/start' || pathname === '/api/browser/start') {
+    if (pathname === '/api/v1/user/create' || pathname === '/api/v2/browser-profile/create' || pathname === '/api/profiles/create') {
+      if (!this.engine) return fail('profile engine unavailable');
+      const body = input && typeof input.profile === 'object' ? { ...input, ...input.profile } : input;
+      const existingIds = new Set(this.engine.profiles ? [...this.engine.profiles.keys()] : []);
+      let id = String(body.user_id || body.profile_id || body.id || '').trim();
+      if (!id) {
+        do { id = 'ob-' + Date.now().toString(36) + '-' + crypto.randomBytes(5).toString('hex'); } while (existingIds.has(id));
+      }
+      if (!/^[A-Za-z0-9_-]{1,64}$/.test(id)) return fail('invalid profile id');
+      if (existingIds.has(id)) return fail('profile already exists');
+      const numbers = this.engine.profiles ? [...this.engine.profiles.values()].map((item) => Number(item.number)).filter((n) => Number.isInteger(n) && n > 0) : [];
+      const number = Number.isInteger(Number(body.number)) && Number(body.number) > 0 ? Number(body.number) : ((Math.max(0, ...numbers) || 0) + 1);
+      const rawProxy = String(body.proxy || '').trim();
+      const userProxy = body.user_proxy_config && typeof body.user_proxy_config === 'object' ? body.user_proxy_config : {};
+      const proxyType = String(userProxy.proxy_type || 'http').toLowerCase();
+      const proxyHost = String(userProxy.proxy_host || '').trim();
+      const proxyPort = String(userProxy.proxy_port || '').trim();
+      const proxyUser = String(userProxy.proxy_user || '');
+      const proxyPassword = String(userProxy.proxy_password || '');
+      const proxy = rawProxy || (proxyHost && proxyPort ? (proxyType === 'socks' ? 'socks5' : proxyType) + '://' + (proxyUser ? encodeURIComponent(proxyUser) + ':' + encodeURIComponent(proxyPassword) + '@' : '') + proxyHost + ':' + proxyPort : 'Direct');
+      const profile = {
+        ...body,
+        id, number,
+        name: String(body.name || body.title || ('Environment ' + number)),
+        title: String(body.title || body.name || ('Environment ' + number)),
+        language: String(body.language || 'en-US'),
+        networkMode: body.networkMode || (/^(direct|offline|none)$/i.test(proxy) ? 'direct' : 'proxy'),
+        proxy,
+        privacy: {
+          ...(body.privacy && typeof body.privacy === 'object' ? body.privacy : {}),
+        },
+      };
+      this.engine.syncProfiles([profile]);
+      if (typeof this.engine.persist === 'function') await this.engine.persist();
+      const created = this.engine.profiles.get(id) || profile;
+      return ok({ user_id: id, profile_id: id, id, profile: created });
+    }
+
+    if (pathname === '/api/v1/user/delete' || pathname === '/api/v2/browser-profile/delete' || pathname === '/api/profiles/delete') {
+      if (!this.engine) return fail('profile engine unavailable');
+      const rawIds = Array.isArray(input.user_ids) ? input.user_ids : (Array.isArray(input.profile_ids) ? input.profile_ids : (Array.isArray(input.ids) ? input.ids : [input.user_id || input.profile_id || input.id]));
+      const ids = rawIds.map((value) => String(value || '').trim()).filter(Boolean);
+      if (!ids.length) return fail('profile id required');
+      const result = await this.engine.deleteProfiles(ids, input.delete_data !== false && input.deleteData !== false);
+      return ok(result);
+    }    if (pathname === '/api/v1/browser/start' || pathname === '/api/v2/browser-profile/start' || pathname === '/api/browser/start') {
       const id = String(input.user_id || input.profile_id || input.id || '');
       const profile = this.engine.profiles.get(id);
       if (!profile) return fail('profile not found');


### PR DESCRIPTION
﻿## Summary

The Local API currently supports listing, starting, and stopping profiles, but has no way to **create** or **delete** profiles programmatically. This means automation tools must rely on pre-created profiles or the UI, which breaks fully headless/automated workflows.

This PR adds two new endpoints to `Browserapp/automation/local-api-server.js`:

---

### `POST /api/v1/user/create`
Also available at `/api/v2/browser-profile/create` and `/api/profiles/create`.

Creates a new browser profile and persists it via `engine.syncProfiles()`.

**Request body:**
```json
{
  "name": "my-profile",
  "language": "en-US",
  "proxy": "http://user:pass@host:port",
  "privacy": {
    "languageMode": "en-US",
    "timezoneMode": "ip"
  }
}
```
Also accepts AdsPower-style `user_proxy_config` object for proxy.

**Response:**
```json
{
  "code": 0,
  "msg": "success",
  "data": {
    "user_id": "ob-abc123",
    "profile_id": "ob-abc123",
    "id": "ob-abc123",
    "profile": { ... }
  }
}
```

---

### `POST /api/v1/user/delete`
Also available at `/api/v2/browser-profile/delete` and `/api/profiles/delete`.

Stops (if running) and deletes one or more profiles via `engine.deleteProfiles()`.

**Request body:**
```json
{ "user_id": "ob-abc123", "delete_data": true }
```
Also accepts `user_ids`, `profile_ids`, or `ids` array for batch delete.

**Response:**
```json
{
  "code": 0,
  "msg": "success",
  "data": { "success": true, "deleted": 1, "stopped": 0, "ids": ["ob-abc123"] }
}
```

---

## Motivation

Automation pipelines (e.g. browser-based account registration, testing) need one fresh isolated profile per task. Without create/delete API support, there is no clean way to manage profile lifecycle programmatically. These two endpoints make the Local API self-sufficient for full profile lifecycle management without needing the UI.
