### PR TITLE
fix: 新增代理未填整行粘贴时检查代理报 proxy required

### DIFF
--- a/Browserapp/renderer.js
+++ b/Browserapp/renderer.js
@@ -4035,7 +4035,13 @@ $('#proxy-dialog-test')?.addEventListener('click', async () => {
     const draft = readProxyForm();
     output.className = 'proxy-test-result';
     output.textContent = tx('正在检测…');
-    const result = await window.ops.proxyCheck(draft.id ? { id: draft.id } : { proxy: draft.raw || undefined, ...draft });
+    let proxyValue = draft.raw;
+    if (!proxyValue && draft.host && Number.isInteger(draft.port) && draft.port > 0 && draft.port <= 65535) {
+      const auth = draft.username ? `${encodeURIComponent(draft.username)}:${encodeURIComponent(draft.password || '')}@` : '';
+      proxyValue = `${draft.protocol || 'socks5'}://${auth}${draft.host}:${draft.port}`;
+    }
+    if (!proxyValue) throw new Error(tx('请先填写主机和端口'));
+    const result = await window.ops.proxyCheck(draft.id ? { id: draft.id } : { proxy: proxyValue, ...draft });
     output.className = 'proxy-test-result success';
     output.textContent = tx('连接成功 · ') + result.ip + (result.countryCode ? ' · ' + result.countryCode : '');
     if (draft.id) await refreshProxies();


### PR DESCRIPTION
fix: 新增代理未填整行粘贴时“检查代理”报 proxy required

## 问题

代理对话框里“主机/端口”必填、“整行粘贴”可选，但“检查代理”按钮此前只读取整行粘贴（`draft.raw`）。新增代理时若只填主机和端口，`proxy:check` 收到的 payload 里没有可用的代理串，主进程抛 `Error: proxy required`。

## 修复

`Browserapp/renderer.js` 的 `#proxy-dialog-test` 处理逻辑：

- 未填整行粘贴时，按与代理库保存（`automation/proxy-store.js` normalizeProxyRecord）一致的规则组装 `protocol://[user:pass@]host:port` 再检测；
- 主机或端口缺失时给出友好提示“请先填写主机和端口”，不再暴露原始英文错误。

## 验证

- `node --check renderer.js` 语法通过
- `node proxy-format-selftest.js` 通过（bare_socks5 / bare_http / bare_https 解析正常，组装串可被 parseProxy 接受）
