### PR TITLE
fix: stop injecting --no-proxy-server on macOS Dock wrapper (real IP leak)

### DIFF
--- a/Browserapp/automation/env-icon-selftest.js
+++ b/Browserapp/automation/env-icon-selftest.js
@@ -18,6 +18,16 @@ async function main() {
       assert.ok(bytes.length > 64);
       assert.strictEqual(bytes.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
     }
+    const src = fs.readFileSync(path.join(__dirname, 'env-icon.js'), 'utf8');
+    assert.ok(
+      !src.includes('EXTRA+=(--no-proxy-server)'),
+      'macOS Dock wrapper must not inject --no-proxy-server (Chromium treats it as Direct and leaks the real IP)',
+    );
+    assert.ok(!/\bHAS_NOPROXY\b/.test(src), 'HAS_NOPROXY tracking is unused after the proxy leak fix');
+    assert.ok(
+      /ARTIFACT_STAMP_VERSION = 3/.test(src),
+      'stamp version must bump so existing Dock wrappers rebuild without --no-proxy-server',
+    );
     console.log('env-icon-selftest: ok');
   } finally {
     await fsp.rm(root, { recursive: true, force: true }).catch(() => {});

--- a/Browserapp/automation/env-icon.js
+++ b/Browserapp/automation/env-icon.js
@@ -437,7 +437,8 @@ function rebuildAppShortcutIcons() {
  */
 // v2: the Dock wrapper now strips CFBundleIconName, so wrappers built by v1 must be rebuilt
 // or they keep resolving their icon out of the kernel's asset catalog.
-const ARTIFACT_STAMP_VERSION = 2;
+// v3: do not inject --no-proxy-server (it overrides Chromium --proxy-server and leaks the real IP).
+const ARTIFACT_STAMP_VERSION = 3;
 
 /** True when the stamp matches and every expected output is still present. */
 function artifactIsFresh(stampPath, key, outputs) {
@@ -807,7 +808,7 @@ for a in "\$@"; do
   esac
 done
 
-USER_DATA=""; HAS_STORE=0; HAS_BROWSER_ID=0; HAS_NO_SANDBOX=0; HAS_MOCK=0; HAS_REMOTE=0; HAS_NOPROXY=0; HAS_DDE=0
+USER_DATA=""; HAS_STORE=0; HAS_BROWSER_ID=0; HAS_NO_SANDBOX=0; HAS_MOCK=0; HAS_REMOTE=0; HAS_DDE=0
 for a in "\$@"; do
   case "\$a" in
     --user-data-dir=*) USER_DATA="\${a#--user-data-dir=}" ;;
@@ -816,7 +817,6 @@ for a in "\$@"; do
     --no-sandbox) HAS_NO_SANDBOX=1 ;;
     --use-mock-keychain) HAS_MOCK=1 ;;
     --remote-allow-origins=*) HAS_REMOTE=1 ;;
-    --no-proxy-server) HAS_NOPROXY=1 ;;
     --do-not-de-elevate) HAS_DDE=1 ;;
   esac
 done
@@ -917,7 +917,6 @@ fi
 [[ "\$HAS_NO_SANDBOX" -eq 0 ]] && EXTRA+=(--no-sandbox)
 [[ "\$HAS_MOCK" -eq 0 ]] && EXTRA+=(--use-mock-keychain)
 [[ "\$HAS_REMOTE" -eq 0 ]] && EXTRA+=(--remote-allow-origins=*)
-[[ "\$HAS_NOPROXY" -eq 0 ]] && EXTRA+=(--no-proxy-server)
 [[ "\$HAS_DDE" -eq 0 ]] && EXTRA+=(--do-not-de-elevate)
 
 # IPC stub detached (survives exec); next launch re-binds the same sockets

--- a/Browserapp/engine.js
+++ b/Browserapp/engine.js
@@ -1811,9 +1811,27 @@ class BrowserEngine {
     });
   }
 
+  restoreStoredProxyCredentials(incoming) {
+    const previous = this.profiles.get(incoming.id);
+    if (!previous) return incoming;
+    const nextProxy = String(incoming.proxy || '');
+    const prevProxy = String(previous.proxy || '');
+    const nextHasAuth = /:\/\/[^/@]+@/.test(nextProxy) || nextProxy.split(':').length >= 4;
+    const prevHasAuth = /:\/\/[^/@]+@/.test(prevProxy) || prevProxy.split(':').length >= 4;
+    if (!prevHasAuth || nextHasAuth) return incoming;
+    try {
+      const prev = parseProxy(prevProxy);
+      const bare = parseProxy(nextProxy);
+      if (prev && bare && prev.host === bare.host && prev.port === bare.port) {
+        return this.sanitizeProfile({ ...incoming, networkMode: 'proxy', proxy: prevProxy });
+      }
+    } catch (_) {}
+    return incoming;
+  }
+
   async start(raw) {
     // let: language/timezone resolution reassigns profile via applyResolvedLocale
-    let profile = this.sanitizeProfile(raw); this.profiles.set(profile.id, profile);
+    let profile = this.restoreStoredProxyCredentials(this.sanitizeProfile(raw)); this.profiles.set(profile.id, profile);
     if (this.running.has(profile.id)) {
       if (!profile.advanced.multiOpen) return this.publicRunning(profile.id);
       return this.publicRunning(profile.id);
@@ -1963,6 +1981,8 @@ class BrowserEngine {
     }
     if (proxy) {
       args.push(`--proxy-server=${proxy}`);
+      // HTTP/SOCKS proxies are IPv4; disable IPv6 so Chrome cannot skip the proxy.
+      if (!args.includes('--disable-ipv6')) args.push('--disable-ipv6');
       // 本机启动页必须直连，不走代理；可叠加用户直连白名单
       let bypass = '<-loopback>;127.0.0.1;localhost';
       if (profile.proxyMeta?.directBypass && profile.proxyMeta.bypassList) {

--- a/Browserapp/env-artifact-cache-selftest.js
+++ b/Browserapp/env-artifact-cache-selftest.js
@@ -92,6 +92,11 @@ const ok = (n, c) => { assert.ok(c, n); console.log('  PASS  ' + n); passed += 1
       ok('wrapper shows the environment name', /<key>CFBundleName<\/key>\s*<string>环境 24<\/string>/.test(plist));
       const icns = path.join(appRoot, 'Contents', 'Resources', 'app.icns');
       ok('generated icon is a real file, not the kernel symlink', fs.existsSync(icns) && !fs.lstatSync(icns).isSymbolicLink() && fs.statSync(icns).size > 1000);
+      const launcherSrc = fs.readFileSync(launcher, 'utf8');
+      ok(
+        'Dock wrapper does not inject --no-proxy-server (would override --proxy-server)',
+        !launcherSrc.includes('EXTRA+=(--no-proxy-server)'),
+      );
     } else {
       console.log('  SKIP  macOS kernel not present — Dock wrapper checks not exercised');
     }

--- a/Browserapp/proxy-feature-selftest.js
+++ b/Browserapp/proxy-feature-selftest.js
@@ -34,6 +34,7 @@ function makeEngineStub() {
   engine.prepareProfileProxyForStart = BrowserEngine.prototype.prepareProfileProxyForStart.bind(engine);
   engine.refreshProfileProxy = BrowserEngine.prototype.refreshProfileProxy.bind(engine);
   engine.applyResolvedLocale = BrowserEngine.prototype.applyResolvedLocale.bind(engine);
+  engine.restoreStoredProxyCredentials = BrowserEngine.prototype.restoreStoredProxyCredentials.bind(engine);
   return engine;
 }
 
@@ -237,6 +238,33 @@ async function main() {
   assert.strictEqual(store.get(item.id).lastCheckOk, false);
   assert.strictEqual(store.get(item.id).lastErrorClass, 'auth');
   fs.rmSync(dir, { recursive: true, force: true });
+
+  // UI localStorage redacts proxy auth. Start must restore credentials from engine state
+  // when host:port still match, otherwise Chrome launches without the local auth bridge.
+  const credEngine = makeEngineStub();
+  const stored = credEngine.sanitizeProfile({
+    id: 'prof_proxy_auth_restore',
+    name: 'auth-restore',
+    networkMode: 'proxy',
+    proxy: 'http://user:secret@14.224.225.102:19125',
+  });
+  credEngine.profiles.set(stored.id, stored);
+  const redacted = credEngine.sanitizeProfile({
+    id: stored.id,
+    name: stored.name,
+    networkMode: 'proxy',
+    proxy: 'http://14.224.225.102:19125/',
+  });
+  const restored = credEngine.restoreStoredProxyCredentials(redacted);
+  assert.ok(restored.proxy.includes('user:secret@'), 'redacted UI proxy must restore stored credentials, got ' + restored.proxy);
+  assert.strictEqual(restored.networkMode, 'proxy');
+  const otherHost = credEngine.restoreStoredProxyCredentials(credEngine.sanitizeProfile({
+    id: stored.id,
+    name: stored.name,
+    networkMode: 'proxy',
+    proxy: 'http://10.0.0.1:8080',
+  }));
+  assert.ok(!otherHost.proxy.includes('user:secret@'), 'must not copy credentials onto a different host:port');
 
   // --- renderer wiring integrity ---
   const renderer = fs.readFileSync(path.join(__dirname, 'renderer.js'), 'utf8');


### PR DESCRIPTION
## Summary

On macOS, launching a profile through the env Dock wrapper injected `--no-proxy-server` in front of Chromium. Chromium treats that flag as **Direct** and **ignores** `--proxy-server`, so HTTP/SOCKS profiles still used the machine IP even when proxy credentials were stored correctly.

This was confirmed by starting an authenticated HTTP proxy profile: the browser showed the real exit IP until the Dock wrapper stopped adding `--no-proxy-server`. After the fix, the same profile used the local auth bridge (`--proxy-server=http://127.0.0.1:…`) and `api.ipify.org` returned the proxy exit IP.

`kernel-init-sync.js` already documents that OpenBrowser relies on Chromium `--proxy-server` (init `proxy` is left empty). Injecting `--no-proxy-server` on the Dock shell contradicts that contract.

## Changes

1. **`Browserapp/automation/env-icon.js`**
   - Stop adding `--no-proxy-server` to Dock launcher extras.
   - Bump `ARTIFACT_STAMP_VERSION` to `3` so existing env `.app` wrappers rebuild.

2. **`Browserapp/engine.js`**
   - Restore stored proxy username/password when the renderer starts a profile with a redacted `http://host:port` URL (localStorage strips auth). Without this, Chrome never starts the local auth bridge.
   - Pass `--disable-ipv6` when a proxy is active so IPv6 cannot skip the IPv4 proxy.

3. **Tests**
   - Source + generated-launcher assertions that the Dock script does not inject `--no-proxy-server`.
   - `restoreStoredProxyCredentials` host:port match / mismatch cases.

## How to verify

```bash
cd Browserapp
node automation/env-icon-selftest.js
node proxy-feature-selftest.js
```

Then on macOS: create a profile with an authenticated HTTP proxy, start it, visit `https://api.ipify.org`. The reported IP should be the proxy exit, not the host.

Process argv should include `--proxy-server=http://127.0.0.1:<bridge>` and must **not** include `--no-proxy-server`.

## Notes

Existing Dock wrappers under `~/Library/Application Support/openbrowser/env-apps/` rebuild on next start because the artifact stamp version changed.