### PR TITLE
feat: RPA 异步运行(wait:false)与 MCP 按调用超时

### DIFF
--- a/Browserapp/automation/README.md
+++ b/Browserapp/automation/README.md
@@ -172,6 +172,8 @@ MCP 提供 45+ 个工具，覆盖：
 - RPA：计划 / 任务 / 模板 / 运行 / 停止 / 结果查询 / 历史清理
 - 应用中心：列表
 
+RPA 执行链路：`rpa_run_steps` / `rpa_run_plan` 支持 `wait:false` 立即返回 task_id，再用 `rpa_task_result` 轮询（返回值含 `variables` / `exports` / `remarks`）；同步等待最长 10 分钟。长任务务必用异步模式，否则会撞上客户端超时。
+
 ### 权限控制
 
 每个工具标注最低权限等级，`tools/list` 和 `tools/call` 都会执行检查：

--- a/Browserapp/automation/automation-selftest.js
+++ b/Browserapp/automation/automation-selftest.js
@@ -579,6 +579,19 @@ async function main() {
   assert.strictEqual(rpaStatus.body.code, 0);
   ok('local-api rpa/status');
 
+  const asyncRun = await httpJson(port, 'POST', '/api/rpa/run', { profile_id: 'p1', steps: [{ type: 'wait', ms: 30 }], wait: false }, authHeaders);
+  assert.strictEqual(asyncRun.body.code, 0);
+  assert.strictEqual(asyncRun.body.data.async, true, 'async rpa run returns immediately');
+  assert.ok(asyncRun.body.data.task_id, 'async rpa run returns task_id');
+  let asyncDone = null;
+  for (let i = 0; i < 50 && !asyncDone; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const probe = await httpJson(port, 'GET', '/api/rpa/tasks/' + encodeURIComponent(asyncRun.body.data.task_id), undefined, authHeaders);
+    if (probe.body.data.task.status !== 'running') asyncDone = probe.body.data.task;
+  }
+  assert.strictEqual(asyncDone && asyncDone.status, 'success', 'async rpa task completes and is pollable');
+  ok('local-api rpa async run + poll');
+
   const rpaTasksLimited = await httpJson(port, 'GET', '/api/rpa/tasks?limit=2', undefined, authHeaders);
   assert.strictEqual(rpaTasksLimited.body.code, 0);
   assert.ok(rpaTasksLimited.body.data.list.length <= 2, 'rpa task list honors limit');
@@ -599,8 +612,16 @@ async function main() {
   assert.ok(TOOLS.some((tool) => tool.name === 'list_applications'));
   assert.ok(TOOLS.some((tool) => tool.name === 'window_sync_start'));
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_run_steps'));
+  const runStepsTool = TOOLS.find((tool) => tool.name === 'rpa_run_steps');
+  assert.ok(runStepsTool.inputSchema.properties.wait, 'rpa_run_steps exposes wait for async runs');
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_task_result'), 'mcp exposes task result retrieval');
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_tasks'), 'mcp exposes task listing');
+  assert.ok(TOOLS.some((tool) => tool.name === 'rpa_run_plan'), 'mcp exposes saved-plan run');
+  assert.ok(TOOLS.some((tool) => tool.name === 'rpa_plans_list'), 'mcp exposes plan management');
+  assert.ok(TOOLS.some((tool) => tool.name === 'create_profile'), 'mcp exposes profile create');
+  assert.ok(TOOLS.some((tool) => tool.name === 'proxy_create'), 'mcp exposes proxy management');
+  assert.ok(TOOLS.some((tool) => tool.name === 'extension_assign'), 'mcp exposes extension assignment');
+  assert.ok(TOOLS.length >= 30, 'mcp tool surface covers local api domains');
   ok('mcp tools registered (' + TOOLS.length + ')');
 
   // Point MCP request helper at our server by temporarily monkey-patching env... callTool uses fixed env.

--- a/Browserapp/automation/local-api-server.js
+++ b/Browserapp/automation/local-api-server.js
@@ -621,14 +621,36 @@ class LocalApiServer {
       return ok(await this.rpaStore.deleteTask(id));
     }
     if (pathname === '/api/rpa/run' || pathname === '/api/rpa' || pathname === '/api/rpav2') {
-      if (input.plan_id) return ok(await this.rpaEngine.runPlan(String(input.plan_id), input));
-      if (input.task_id) return ok(await this.rpaEngine.runTask(String(input.task_id), input));
+      // wait:false starts the run and returns task ids immediately — poll
+      // /api/rpa/tasks/:id for the outcome. Keeps long runs off synchronous
+      // client timeouts (runTask awaits every step otherwise).
+      const wait = input.wait !== false && input.wait !== 'false';
+      if (input.plan_id) {
+        if (!wait) {
+          // runTask resolves {success:false} on task failure; this catch only
+          // guards true anomalies (e.g. the task was deleted mid-run).
+          this.rpaEngine.runPlan(String(input.plan_id), input).catch(() => {});
+          return ok({ async: true, plan_id: String(input.plan_id) });
+        }
+        return ok(await this.rpaEngine.runPlan(String(input.plan_id), input));
+      }
+      if (input.task_id) {
+        if (!wait) {
+          this.rpaEngine.runTask(String(input.task_id), input).catch(() => {});
+          return ok({ async: true, task_id: String(input.task_id) });
+        }
+        return ok(await this.rpaEngine.runTask(String(input.task_id), input));
+      }
       if (Array.isArray(input.steps)) {
         const task = await this.rpaStore.createTask({
           profile_id: String(input.profile_id || input.user_id || ''),
           process_name: String(input.name || 'adhoc'),
           steps: input.steps,
         });
+        if (!wait) {
+          this.rpaEngine.runTask(task.id, input).catch(() => {});
+          return ok({ async: true, task_id: task.id });
+        }
         return ok(await this.rpaEngine.runTask(task.id, input));
       }
       return fail('plan_id, task_id or steps required');

--- a/Browserapp/automation/mcp-server.js
+++ b/Browserapp/automation/mcp-server.js
@@ -13,6 +13,20 @@
  *   OPENBROWSER_MCP_MODE=admin|manage|run|read
  *   OPENBROWSER_MCP_TOOL_BLACKLIST=json array of tool names
  *   OPENBROWSER_MCP_TOOL_WHITELIST=json array of tool names
+ *
+ * Run standalone:
+ *   OPENBROWSER_API_PORT=50325 OPENBROWSER_API_KEY=your_api_key node automation/mcp-server.js
+ *
+ * Cursor / Claude Desktop config example:
+ * {
+ *   "mcpServers": {
+ *     "openbrowser-local-api": {
+ *       "command": "node",
+ *       "args": ["/path/to/Browserapp/automation/mcp-server.js"],
+ *       "env": { "OPENBROWSER_API_PORT": "50325", "OPENBROWSER_API_KEY": "your_api_key" }
+ *     }
+ *   }
+ * }
  */
 
 const http = require('http');
@@ -38,7 +52,7 @@ function parseJsonEnv(value, fallback) {
   }
 }
 
-function request(method, path, body) {
+function request(method, path, body, options = {}) {
   const payload = body === undefined ? null : JSON.stringify(body);
   return new Promise((resolve, reject) => {
     const req = http.request({
@@ -51,7 +65,7 @@ function request(method, path, body) {
         ...(API_KEY ? { 'api-key': API_KEY } : {}),
         ...(payload ? { 'Content-Length': Buffer.byteLength(payload) } : {}),
       },
-      timeout: 60000,
+      timeout: Number(options.timeout) || 60000,
     }, (res) => {
       let data = '';
       res.setEncoding('utf8');
@@ -100,7 +114,6 @@ function toolsMeta() {
     ['isolation_audit', 'Audit isolation collisions (user-data dirs and CDP ports)', { type: 'object', properties: {}, additionalProperties: false }, 'read', 'GET', '/api/isolation/audit', null],
     ['window_sync_settings_get', 'Get current multi-window sync settings', { type: 'object', properties: {}, additionalProperties: false }, 'read', 'GET', '/api/sync/settings', null],
     ['rpa_plans_list', 'List saved RPA plans', { type: 'object', properties: {}, additionalProperties: false }, 'read', 'GET', '/api/rpa/plans', null],
-    ['rpa_tasks_list', 'List RPA tasks', { type: 'object', properties: { status: { type: 'string' }, limit: { type: 'integer', minimum: 1, maximum: 500 } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks', null],
     ['rpa_task_result', 'Get one RPA task by id, including process_result (variables / exports / remarks) and persisted logs', { type: 'object', properties: { task_id: { type: 'string' } }, required: ['task_id'], additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks/', null],
     ['rpa_tasks', 'List RPA tasks newest first (optionally filtered by status)', { type: 'object', properties: { status: { type: 'string' }, limit: { type: 'integer', minimum: 1, maximum: 500 } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks', null],
     ['rpa_templates_list', 'List RPA templates and categories', { type: 'object', properties: { category: { type: 'string' } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/templates', null],
@@ -169,10 +182,14 @@ function toolsMeta() {
     ['window_sync_arrange', 'Arrange windows in tile or cascade mode', { type: 'object', properties: { profile_ids: { type: 'array', items: { type: 'string' } }, mode: { type: 'string', enum: ['tile', 'cascade'] } }, additionalProperties: false }, 'run', 'POST', '/api/sync/arrange', null],
     ['window_sync_settings_update', 'Update multi-window sync settings', { type: 'object', properties: { settings: { type: 'object' } }, required: ['settings'], additionalProperties: false }, 'manage', 'POST', '/api/sync/settings', null],
     // RPA
-    ['rpa_run_steps', 'Run RPA steps on a running profile', { type: 'object', properties: {
+    ['rpa_run_steps', 'Run RPA steps on a running profile. Set wait:false to get a task_id immediately and poll rpa_task_result', { type: 'object', properties: {
       profile_id: { type: 'string' }, steps: { type: 'array', items: { type: 'object' } }, name: { type: 'string' },
+      wait: { type: 'boolean', description: 'default true (blocks up to 10 min); false returns task_id immediately' },
     }, required: ['profile_id', 'steps'], additionalProperties: false }, 'run', 'POST', '/api/rpa/run', null],
-    ['rpa_run_plan', 'Run a saved RPA plan', { type: 'object', properties: { plan_id: { type: 'string' }, name: { type: 'string' } }, required: ['plan_id'], additionalProperties: false }, 'run', 'POST', '/api/rpa/run', null],
+    ['rpa_run_plan', 'Run a saved RPA plan. Set wait:false to start it and poll rpa_task_result / rpa_tasks', { type: 'object', properties: {
+      plan_id: { type: 'string' }, name: { type: 'string' },
+      wait: { type: 'boolean', description: 'default true (blocks up to 10 min); false returns task_id immediately' },
+    }, required: ['plan_id'], additionalProperties: false }, 'run', 'POST', '/api/rpa/run', null],
     ['rpa_stop', 'Stop RPA task(s)', { type: 'object', properties: { task_id: { type: 'string' } }, additionalProperties: false }, 'run', 'POST', '/api/rpa/stop', null],
     ['rpa_plan_save', 'Create or update an RPA plan', { type: 'object', properties: {
       plan_name: { type: 'string' }, profile_ids: { type: 'array', items: { type: 'string' } }, steps: { type: 'array', items: { type: 'object' } }, plan_id: { type: 'string' },
@@ -339,9 +356,14 @@ async function callTool(name, args = {}) {
         profile_id: args.profile_id,
         steps: args.steps,
         name: args.name || 'mcp-rpa',
-      });
+        wait: args.wait !== false,
+      }, { timeout: args.wait === false ? 30000 : 600000 });
     case 'rpa_run_plan':
-      return request('POST', '/api/rpa/run', { plan_id: args.plan_id, name: args.name });
+      return request('POST', '/api/rpa/run', {
+        plan_id: args.plan_id,
+        name: args.name,
+        wait: args.wait !== false,
+      }, { timeout: args.wait === false ? 30000 : 600000 });
     case 'rpa_status':
       return request('GET', '/api/rpa/status');
     case 'rpa_stop':
@@ -352,8 +374,6 @@ async function callTool(name, args = {}) {
       return request('POST', '/api/rpa/plans', args);
     case 'rpa_plan_delete':
       return request('DELETE', `/api/rpa/plans/${encodeURIComponent(args.plan_id)}`);
-    case 'rpa_tasks_list':
-      return request('GET', '/api/rpa/tasks' + queryString(args));
     case 'rpa_task_result':
       return request('GET', '/api/rpa/tasks/' + encodeURIComponent(String(args.task_id || '')));
     case 'rpa_tasks':


### PR DESCRIPTION
## 问题

上游 `1db2c07` 之后,MCP 的 `rpa_run_steps` / `rpa_run_plan` 调用 `POST /api/rpa/run` 默认同步等待任务结束,而 MCP 侧 HTTP 请求超时固定 60 秒:

- 跑一个超过 60 秒的 RPA 任务时,任务在服务端继续执行,但 MCP 工具调用已经报超时失败,AI 无法可靠拿到结果,也不知道任务是否还在跑。

## 方案

**API 层**(`local-api-server.js`):
- `POST /api/rpa/run` 支持 `wait:false`(缺省 `true`,行为完全不变):立即返回 `{ async: true, task_id | plan_id }`,客户端用 `GET /api/rpa/tasks/:id` 轮询结果。
- 对 `plan_id` / `task_id` / `steps` 三种入参形态都支持。

**MCP 层**(`mcp-server.js`):
- `rpa_run_steps` / `rpa_run_plan` 的 schema 暴露 `wait` 字段并说明语义。
- `request()` 支持按调用传入超时:同步等待 10 分钟,异步启动 30 秒——长任务不再撞上固定 60 秒上限。

**顺带的小清理**(如果觉得不合适可以单独摘掉):
- 删除与 `rpa_tasks` 指向同一端点、schema 相同的重复工具 `rpa_tasks_list`。
- 文件头补回运行命令与 Cursor 配置示例(`automation/README.md` 里引用了该注释)。

## 测试

- `automation-selftest.js` 新增用例:异步启动返回 task_id → 轮询至完结;断言 `rpa_run_steps` schema 暴露 `wait`。
- `automation-selftest` 全部通过(49 工具注册);同一代码在 `mcp-control-selftest` 26 项检查通过(本机 50325 被运行中的应用占用,故该测试在合并代码上验证)。

## 兼容性

默认行为不变(`wait` 缺省 `true`),已有客户端无感知。