### PR TITLE
feat: RPA 任务删除的用户入口(IPC + 任务表 UI + MCP 工具)

### DIFF
--- a/Browserapp/automation/automation-selftest.js
+++ b/Browserapp/automation/automation-selftest.js
@@ -601,6 +601,7 @@ async function main() {
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_run_steps'));
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_task_result'), 'mcp exposes task result retrieval');
   assert.ok(TOOLS.some((tool) => tool.name === 'rpa_tasks'), 'mcp exposes task listing');
+  assert.ok(TOOLS.some((tool) => tool.name === 'rpa_task_delete'), 'mcp exposes task delete');
   ok('mcp tools registered (' + TOOLS.length + ')');
 
   // Point MCP request helper at our server by temporarily monkey-patching env... callTool uses fixed env.

--- a/Browserapp/automation/mcp-server.js
+++ b/Browserapp/automation/mcp-server.js
@@ -101,6 +101,7 @@ function toolsMeta() {
     ['window_sync_settings_get', 'Get current multi-window sync settings', { type: 'object', properties: {}, additionalProperties: false }, 'read', 'GET', '/api/sync/settings', null],
     ['rpa_plans_list', 'List saved RPA plans', { type: 'object', properties: {}, additionalProperties: false }, 'read', 'GET', '/api/rpa/plans', null],
     ['rpa_tasks_list', 'List RPA tasks', { type: 'object', properties: { status: { type: 'string' }, limit: { type: 'integer', minimum: 1, maximum: 500 } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks', null],
+    ['rpa_task_delete', 'Delete one RPA task (and its run record) by id', { type: 'object', properties: { task_id: { type: 'string' } }, required: ['task_id'], additionalProperties: false }, 'manage', 'DELETE', '/api/rpa/tasks/', null],
     ['rpa_task_result', 'Get one RPA task by id, including process_result (variables / exports / remarks) and persisted logs', { type: 'object', properties: { task_id: { type: 'string' } }, required: ['task_id'], additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks/', null],
     ['rpa_tasks', 'List RPA tasks newest first (optionally filtered by status)', { type: 'object', properties: { status: { type: 'string' }, limit: { type: 'integer', minimum: 1, maximum: 500 } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/tasks', null],
     ['rpa_templates_list', 'List RPA templates and categories', { type: 'object', properties: { category: { type: 'string' } }, additionalProperties: false }, 'read', 'GET', '/api/rpa/templates', null],
@@ -356,6 +357,8 @@ async function callTool(name, args = {}) {
       return request('GET', '/api/rpa/tasks' + queryString(args));
     case 'rpa_task_result':
       return request('GET', '/api/rpa/tasks/' + encodeURIComponent(String(args.task_id || '')));
+    case 'rpa_task_delete':
+      return request('DELETE', '/api/rpa/tasks/' + encodeURIComponent(String(args.task_id || '')));
     case 'rpa_tasks':
       return request('GET', '/api/rpa/tasks' + queryString(args));
     case 'rpa_templates_list':

--- a/Browserapp/index.html
+++ b/Browserapp/index.html
@@ -633,6 +633,7 @@
             <div class="rpa-toolbar">
               <button class="primary" type="button" id="rpa-create-task"><i data-lucide="plus"></i>创建任务</button>
               <label class="rpa-search"><input id="rpa-task-search" placeholder="可输入任务名称进行搜索"></label>
+              <button type="button" class="outline" id="rpa-task-delete-checked"><i data-lucide="trash-2"></i>删除选中</button>
               <button type="button" class="outline" id="rpa-task-refresh"><i data-lucide="refresh-cw"></i></button>
             </div>
             <div class="rpa-table-wrap table-card">

--- a/Browserapp/main.js
+++ b/Browserapp/main.js
@@ -1891,6 +1891,21 @@ app.whenReady().then(async () => {
     if (!automation) throw new Error('Automation stack is not ready');
     return automation.rpaStore.deletePlan(String(id || ''));
   });
+  registerTrustedIpc('automation:rpa-task-delete', async (_event, ids) => {
+    if (!automation) throw new Error('Automation stack is not ready');
+    const list = [...new Set((Array.isArray(ids) ? ids : [ids]).map((id) => String(id || '').trim()).filter(Boolean))];
+    // Guard on the engine's live running map only: deleting a task mid-run makes
+    // updateTask throw inside the run loop. A persisted status of 'running'
+    // without a map entry is a stale row from a previous session — deletable.
+    const running = new Set(automation.rpaEngine?.getStatus?.().running || []);
+    const deleted = []; const skipped = [];
+    for (const id of list) {
+      if (running.has(id)) { skipped.push(id); continue; }
+      const result = await automation.rpaStore.deleteTask(id);
+      (result.success ? deleted : skipped).push(id);
+    }
+    return { deleted, skipped };
+  });
   registerTrustedIpc('automation:rpa-run', async (_event, payload) => {
     if (!automation) throw new Error('Automation stack is not ready');
     if (payload?.plan_id) return automation.rpaEngine.runPlan(String(payload.plan_id), payload);

--- a/Browserapp/preload.js
+++ b/Browserapp/preload.js
@@ -58,6 +58,7 @@ contextBridge.exposeInMainWorld('ops', Object.freeze({
   rpaGetPlan: (id) => ipcRenderer.invoke('automation:rpa-get-plan', id),
   rpaSavePlan: (plan) => ipcRenderer.invoke('automation:rpa-save-plan', plan),
   rpaDeletePlan: (id) => ipcRenderer.invoke('automation:rpa-delete-plan', id),
+  rpaTaskDelete: (ids) => ipcRenderer.invoke('automation:rpa-task-delete', ids),
   rpaRun: (payload) => ipcRenderer.invoke('automation:rpa-run', payload),
   rpaStop: (taskId) => ipcRenderer.invoke('automation:rpa-stop', taskId),
   rpaTemplates: (filter) => ipcRenderer.invoke('automation:rpa-templates', filter || {}),

--- a/Browserapp/renderer.js
+++ b/Browserapp/renderer.js
@@ -4652,6 +4652,7 @@ async function refreshRpaTasks() {
   for (const t of list) {
     const row = document.createElement('tr');
     const cb = document.createElement('input'); cb.type = 'checkbox';
+    cb.dataset.rpaTaskCheck = t.id;
     const td0 = document.createElement('td'); td0.append(cb);
     const runBtn = element('button', 'outline', tx('详情'));
     runBtn.onclick = () => {
@@ -4659,7 +4660,9 @@ async function refreshRpaTasks() {
       showRpaPanel('runs');
       toast(tx('见运行记录/日志'));
     };
-    const tdOp = document.createElement('td'); tdOp.append(runBtn);
+    const delBtn = element('button', 'outline rpa-btn-danger', tx('删除'));
+    delBtn.onclick = () => deleteRpaTasks([t.id]);
+    const tdOp = document.createElement('td'); tdOp.append(runBtn, delBtn);
     row.append(
       td0,
       element('td', '', t.process_name || t.id),
@@ -4672,6 +4675,9 @@ async function refreshRpaTasks() {
     );
     table.append(row);
   }
+  // Rows re-render unchecked; keep the header checkbox consistent with them.
+  const selectAll = document.getElementById('rpa-task-select-all');
+  if (selectAll) selectAll.checked = false;
   if (empty) {
     empty.style.display = list.length ? 'none' : 'grid';
   }
@@ -4691,6 +4697,9 @@ async function refreshRpaRuns() {
   if (q) list = list.filter((t) => String(t.process_name || '').toLowerCase().includes(q));
   for (const t of list) {
     const row = document.createElement('tr');
+    const delBtn = element('button', 'outline rpa-btn-danger', tx('删除'));
+    delBtn.onclick = () => deleteRpaTasks([t.id]);
+    const tdOp = document.createElement('td'); tdOp.append(delBtn);
     row.append(
       element('td', '', t.process_name || t.id),
       element('td', '', t.process_name || '—'),
@@ -4698,11 +4707,25 @@ async function refreshRpaRuns() {
       element('td', '', t.status || '—'),
       element('td', '', String(t.start_time || t.create_time || '—').replace('T', ' ').slice(0, 19)),
       element('td', '', String(t.complete_time || '—').replace('T', ' ').slice(0, 19)),
-      element('td', '', '')
+      tdOp
     );
     table.append(row);
   }
   if (empty) empty.style.display = list.length ? 'none' : 'grid';
+}
+
+async function deleteRpaTasks(ids) {
+  if (!ids.length) { toast(tx('请先勾选要删除的任务')); return; }
+  if (!confirm(tx(ids.length > 1 ? `确定删除选中的 ${ids.length} 个任务及其运行记录？` : '确定删除该任务及其运行记录？'))) return;
+  try {
+    const result = await window.ops.rpaTaskDelete(ids);
+    await refreshRpaTasks();
+    await refreshRpaRuns();
+    if (result.skipped?.length) toast(tx(`已删除 ${result.deleted.length} 个，已跳过 ${result.skipped.length} 个（运行中或已不存在）`));
+    else toast(tx(`已删除 ${result.deleted.length} 个任务`));
+  } catch (error) {
+    toast('删除失败：' + error.message);
+  }
 }
 
 function rpaCategoryLabel(cat) {
@@ -4967,6 +4990,13 @@ document.getElementById('rpa-new-plan-2')?.addEventListener('click', () => creat
 document.getElementById('rpa-create-task')?.addEventListener('click', () => createRpaPlan('任务流程 ' + new Date().toLocaleString()).catch((e) => toast(e.message)));
 document.getElementById('rpa-refresh')?.addEventListener('click', refreshRpaPage);
 document.getElementById('rpa-task-refresh')?.addEventListener('click', refreshRpaTasks);
+document.getElementById('rpa-task-delete-checked')?.addEventListener('click', () => {
+  const ids = [...document.querySelectorAll('[data-rpa-task-check]:checked')].map((el) => el.dataset.rpaTaskCheck);
+  deleteRpaTasks(ids);
+});
+document.getElementById('rpa-task-select-all')?.addEventListener('change', (event) => {
+  for (const el of document.querySelectorAll('[data-rpa-task-check]')) el.checked = event.target.checked;
+});
 document.getElementById('rpa-run-refresh')?.addEventListener('click', refreshRpaRuns);
 document.getElementById('rpa-flow-search')?.addEventListener('input', renderRpaPlans);
 document.getElementById('rpa-task-search')?.addEventListener('input', refreshRpaTasks);


### PR DESCRIPTION
## 背景

`1db2c07` 已经提供了存储层的 `deleteTask` 和 `DELETE /api/rpa/tasks/:id` 端点,但目前没有任何入口能用到它——没有 IPC、没有界面、也没有 MCP 工具。本 PR 把删除能力补全成用户可用的闭环。

## 内容

**IPC**(`main.js` / `preload.js`):
- `automation:rpa-task-delete` 支持批量删除;以引擎的运行中任务表为准做保护——运行中的任务跳过并在返回值里报告 `skipped`,避免删除触发运行循环内 `updateTask` 异常;历史会话遗留的持久化 `running` 状态行仍可删除。

**任务表 UI**(`renderer.js` / `index.html`):
- 行内复选框(表头全选联动)、行内删除按钮、工具栏删除选中按钮,均带确认提示;删除后刷新任务与运行记录列表并 toast 汇报结果。

**MCP**(`mcp-server.js`):
- 新增 `rpa_task_delete` 工具(`manage` 级,复用已有 DELETE 端点)。

## 测试

- `automation-selftest.js` 断言 MCP 注册 `rpa_task_delete`,全部通过;语法检查覆盖 `main.js` / `renderer.js`。
- 删除链路与 `1db2c07` 的存储层行为对齐:`deleted` / `skipped` 分组返回。